### PR TITLE
Silence STDOUT logging unless FARADAY_LOGGING set

### DIFF
--- a/lib/vhx/client.rb
+++ b/lib/vhx/client.rb
@@ -20,7 +20,7 @@ module Vhx
       @connection = Faraday::Connection.new(url: api_base_url, headers: configured_headers, ssl: ssl) do |faraday|
         faraday.request  :url_encoded
         faraday.request  :json
-        faraday.response :logger
+        faraday.response :logger unless ENV['FARADAY_LOGGING'].nil?
         faraday.use Vhx::Middleware::OAuth2, :vhx_client => self unless @skip_auto_refresh
 
         faraday.adapter Faraday.default_adapter


### PR DESCRIPTION
I was using this gem for some customer data import and the STDOUT logging was pretty noisy. This silences unless you do e.g.

`FARADAY_LOGGING=1 ruby my-script.rb`

I wasn't sure how to test this, feedback welcome! And hi
