### PR TITLE
0.0.7

### DIFF
--- a/lib/vhx/objects/video.rb
+++ b/lib/vhx/objects/video.rb
@@ -3,5 +3,9 @@ module Vhx
     include Vhx::ApiOperations::Create
     include Vhx::ApiOperations::Request
     include Vhx::ApiOperations::List
+
+    def files(payload = {})
+      fetch_linked_association(@obj_hash, "files", payload)
+    end
   end
 end

--- a/lib/vhx/utilities/vhx_object.rb
+++ b/lib/vhx/utilities/vhx_object.rb
@@ -1,7 +1,7 @@
 module Vhx
   class VhxObject
     include HelperMethods
-    ASSOCIATION_WHITELIST = ['products', 'sites', 'site', 'videos', 'video', 'subscription', 'files', 'items', 'customer']
+    ASSOCIATION_WHITELIST = ['products', 'sites', 'site', 'videos', 'video', 'subscription', 'items', 'customer']
 
     def initialize(obj_hash)
       @obj_hash = obj_hash
@@ -32,10 +32,15 @@ module Vhx
     end
 
     def _links
-      JSON.parse(@obj_hash['_links'].to_json, object_class: OpenStruct)
+      JSON.parse(@obj_hash['_links'].to_json)
+    end
+
+    def _embedded
+      JSON.parse(@obj_hash['_embedded'].to_json)
     end
 
   protected
+
     def validate_class(obj_hash)
       return nil unless obj_hash['_links'].fetch('self', nil)
 
@@ -90,8 +95,7 @@ module Vhx
 
     def fetch_linked_association(obj_hash, association_method, payload = {})
       response = Vhx.connection.get do |req|
-        req.url(obj_hash['_links'][association_method]['href'].gsub(Vhx.client.api_base_url, ""))
-        req.body = payload
+        req.url(obj_hash['_links'][association_method]['href'].gsub(Vhx.client.api_base_url, "") + '?' + URI.encode_www_form(payload))
       end
 
       build_association(response.body, association_method)

--- a/lib/vhx/version.rb
+++ b/lib/vhx/version.rb
@@ -1,3 +1,3 @@
 module Vhx
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
- make sure video.files fetches via links
- add _embedded method
- change _links method to return hash
- for #fetch_linked_association, pass payload via querystring, not in body.

related to: 
- https://app.asana.com/0/8048140348297/158248923020346
- https://app.asana.com/0/8048140348297/158248923020343
- https://app.asana.com/0/8048140348297/158248923020340