### PR TITLE
Version up vhx-ruby gem to 0.0.8. 

### DIFF
--- a/lib/vhx/version.rb
+++ b/lib/vhx/version.rb
@@ -1,3 +1,3 @@
 module Vhx
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end

--- a/vhx.gemspec
+++ b/vhx.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name           = 'vhx-ruby'
   spec.version        = Vhx::VERSION
   spec.authors        = ['Sagar Shah']
-  spec.date           = '2016-02-16'
+  spec.date           = '2017-01-06'
   spec.description    = 'A Ruby wrapper for the Vhx developer API.'
   spec.summary        = 'A Ruby wrapper for the Vhx developer API.'
   spec.email          = ['sagar@vhx.tv', 'dev@vhx.tv', 'wontae@vhx.tv', 'charlie@vhx.tv', 'kevin@vhx.tv', 'scott@vhx.tv']


### PR DESCRIPTION
Changes include:
- Passing unit specs [#7](https://github.com/vhx/vhx-ruby/pull/7)
- Vhx::Analytics resource [#5](https://github.com/vhx/vhx-ruby/pull/5)

Mainly related to: [Update the Ruby client for making anlaytics calls](https://app.asana.com/0/204939087856629/202289670275587)