### PR TITLE
Add update method for Video resource

### DIFF
--- a/lib/vhx/objects/video.rb
+++ b/lib/vhx/objects/video.rb
@@ -1,6 +1,7 @@
 module Vhx
   class Video < VhxObject
     include Vhx::ApiOperations::Create
+    include Vhx::ApiOperations::Update
     include Vhx::ApiOperations::Request
     include Vhx::ApiOperations::List
 

--- a/spec/objects/video_spec.rb
+++ b/spec/objects/video_spec.rb
@@ -53,7 +53,8 @@ describe Vhx::Video do
 
     describe '#udpate' do
       it 'raises error' do
-        expect{Vhx::Video.new({}).update}.to raise_error(NoMethodError)
+        Vhx.connection.stub(:put).and_return(OpenStruct.new(body: video_response))
+        expect{Vhx::Video.new(video_response).update({})}.to_not raise_error(NoMethodError)
       end
     end
 


### PR DESCRIPTION
The ability to update a video object via the API is now possible. This PR is to bring equivalent functionality to the ruby gem. 