### PR TITLE
Add header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ The VHX API is currently Private Beta. You can request an API key by emailing ap
 
 `gem install vhx-ruby`
 
+#### Building Locally
+
+```shell
+$ gem build vhx.gemspec
+Successfully built RubyGem
+Name: vhx
+Version: 0.0.0
+File: vhx-0.0.0.gem
+
+$ gem install vhx-0.0.0.gem
+Successfully installed vhx-0.0.0
+1 gem installed
+
+$ irb
+irb(main)> require 'vhx'
+```
+
+#### Running Specs
+
+```shell
+rspec .
+```
+
 ### Documentation
 
 Documentation is available at http://dev.vhx.tv/docs/api/ruby.
@@ -16,7 +39,7 @@ Full API reference is available at http://dev.vhx.tv/docs/api?ruby.
 Before requesting your first resource, you must setup an instance of the Vhx Client:
 
 ```ruby
-vhx = Vhx.setup({ api_key: 'your VHX API key'} )
+vhx = Vhx.setup({ api_key: 'your VHX API key' })
 ```
 
 Here's an example of creating a Vhx resource with payload options. You can handle errors by rescuing Vhx::VhxError.

--- a/lib/vhx.rb
+++ b/lib/vhx.rb
@@ -36,20 +36,20 @@ module Vhx
 
   class << self
     def setup(options = {})
-      options[:client_id]         ||= @client_id
-      options[:client_secret]     ||= @client_secret
-      options[:api_key]           ||= @api_key
-      options[:api_base]          ||= @api_base_url
-      options[:auto_refresh]        = @auto_refresh || false 
+      options[:client_id]     ||= @client_id
+      options[:client_secret] ||= @client_secret
+      options[:api_key]       ||= @api_key
+      options[:api_base]      ||= @api_base_url
+      options[:auto_refresh]    = @auto_refresh || false
       Vhx.client = Vhx::Client.new(options)
     end
 
     def config(config = {})
-      @client_id          = config[:client_id]
-      @client_secret      = config[:client_secret]
-      @api_key            = config[:api_key]
-      @auto_refresh       = config[:auto_refresh] || false
-      @api_base_url       = config[:api_base]
+      @client_id     = config[:client_id]
+      @client_secret = config[:client_secret]
+      @api_key       = config[:api_key]
+      @auto_refresh  = config[:auto_refresh] || false
+      @api_base_url  = config[:api_base]
     end
 
     def client

--- a/lib/vhx/utilities/api_operations/create.rb
+++ b/lib/vhx/utilities/api_operations/create.rb
@@ -2,10 +2,17 @@ module Vhx
   module ApiOperations
     module Create
       module ClassMethods
-        def create(payload)
+        def create(payload, headers = {})
           klass = get_klass
           response = Vhx.connection.post do |req|
-            req.url('/' + klass.downcase + 's') #This url is based purely on VHX's API convention.
+            req.url('/' + klass.downcase + 's') # This url is based purely on VHX's API convention.
+
+            if headers.length > 0
+              headers.each do |key, value|
+                req.headers[key] = value
+              end
+            end
+
             req.body = payload
           end
 

--- a/lib/vhx/utilities/api_operations/delete.rb
+++ b/lib/vhx/utilities/api_operations/delete.rb
@@ -2,8 +2,12 @@ module Vhx
   module ApiOperations
     module Delete
       module ClassMethods
-        def delete(identifier, payload = {})
-          Vhx.connection.delete(get_hypermedia(identifier), payload)
+        def delete(identifier, payload = {}, headers = {})
+          Vhx.connection.delete(
+            get_hypermedia(identifier),
+            payload,
+            headers,
+          )
         end
       end
 

--- a/lib/vhx/utilities/api_operations/list.rb
+++ b/lib/vhx/utilities/api_operations/list.rb
@@ -4,13 +4,17 @@ module Vhx
   module ApiOperations
     module List
       module ClassMethods
-        def all(payload = {})
-          response = Vhx.connection.get('/' + get_klass.downcase + 's', payload)
+        def all(payload = {}, headers = {})
+          response = Vhx.connection.get(
+            '/' + get_klass.downcase + 's',
+            payload,
+            headers,
+          )
           VhxListObject.new(response.body, get_klass.downcase + 's')
         end
 
-        def list(payload = {})
-          self.all(payload)
+        def list(payload = {}, headers = {})
+          self.all(payload, headers)
         end
       end
 

--- a/lib/vhx/utilities/api_operations/request.rb
+++ b/lib/vhx/utilities/api_operations/request.rb
@@ -2,13 +2,17 @@ module Vhx
   module ApiOperations
     module Request
       module ClassMethods
-        def find(identifier)
-          response = Vhx.connection.get(get_hypermedia(identifier))
+        def find(identifier, payload = {}, headers = {})
+          response = Vhx.connection.get(
+            get_hypermedia(identifier),
+            payload,
+            headers,
+          )
           self.new(response.body)
         end
 
-        def retrieve(identifier)
-          self.find(identifier)
+        def retrieve(identifier, payload = {}, headers = {})
+          self.find(identifier, payload, headers)
         end
       end
 

--- a/lib/vhx/utilities/api_operations/update.rb
+++ b/lib/vhx/utilities/api_operations/update.rb
@@ -2,8 +2,8 @@ module Vhx
   module ApiOperations
     module Update
       module InstanceMethods
-        def update(payload)
-          Vhx.connection.put(self.href, payload)
+        def update(payload, headers = {})
+          Vhx.connection.put(self.href, payload, headers)
         end
       end
 

--- a/lib/vhx/version.rb
+++ b/lib/vhx/version.rb
@@ -1,3 +1,3 @@
 module Vhx
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/spec/objects/customer_spec.rb
+++ b/spec/objects/customer_spec.rb
@@ -12,34 +12,34 @@ describe Vhx::Customer do
   before{
     Vhx.setup({api_key: 'testapikey'})
   }
-  
+
   describe 'api operations' do
 
     describe '::find' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: customer_response))
-        expect{Vhx::Customer.find(123)}.to_not raise_error 
+        expect{Vhx::Customer.find(123)}.to_not raise_error
       end
-    end 
+    end
 
     describe '::retrieve' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: customer_response))
-        expect{Vhx::Customer.retrieve(123)}.to_not raise_error 
+        expect{Vhx::Customer.retrieve(123)}.to_not raise_error
       end
     end
 
     describe '::list' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: customers_response))
-        expect{Vhx::Customer.list()}.to_not raise_error 
+        expect{Vhx::Customer.list()}.to_not raise_error
       end
     end
 
     describe '::all' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: customers_response))
-        expect{Vhx::Customer.all()}.to_not raise_error 
+        expect{Vhx::Customer.all()}.to_not raise_error
       end
     end
 
@@ -61,13 +61,29 @@ describe Vhx::Customer do
         Vhx.connection.stub(:delete).and_return(OpenStruct.new(body: ""))
         expect{Vhx::Customer.delete(1)}.to_not raise_error
       end
+
+      it "supports headers" do
+        params = [
+          :delete,
+          "https://api.vhx.tv/customers/1",
+          nil,
+          { "VHX-Client-IP" => "1.2.3.4" },
+        ]
+        response = OpenStruct.new(body: "")
+
+        expect_any_instance_of(Faraday::Connection).to receive(:run_request).
+                                                       with(*params).
+                                                       and_return(response)
+
+        Vhx::Customer.delete(1, {}, { 'VHX-Client-IP' => '1.2.3.4' })
+      end
     end
 
     describe '#add_product' do
       it 'returns customer' do
         Vhx.connection.stub(:put).and_return(OpenStruct.new(body: customer_response))
         customer = Vhx::Customer.new(customer_response).add_product(1)
-        expect(customer.class).to eq(Vhx::Customer) 
+        expect(customer.class).to eq(Vhx::Customer)
       end
     end
 
@@ -75,7 +91,7 @@ describe Vhx::Customer do
       it 'returns customer' do
         Vhx.connection.stub(:delete).and_return(OpenStruct.new(body: customer_response))
         customer = Vhx::Customer.new(customer_response).remove_product(1)
-        expect(customer.class).to eq(Vhx::Customer) 
+        expect(customer.class).to eq(Vhx::Customer)
       end
     end
   end

--- a/spec/objects/video_spec.rb
+++ b/spec/objects/video_spec.rb
@@ -13,34 +13,66 @@ describe Vhx::Video do
   before{
     Vhx.setup({api_key: 'testapikey'})
   }
-  
+
   describe 'api operations' do
 
     describe '::find' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: video_response))
-        expect{Vhx::Video.find(123)}.to_not raise_error 
+        expect{Vhx::Video.find(123)}.to_not raise_error
       end
-    end 
+
+      it "supports headers" do
+        params = [
+          :get,
+          "https://api.vhx.tv/videos/123",
+          nil,
+          { "VHX-Client-IP" => "1.2.3.4" },
+        ]
+        response = OpenStruct.new(body: video_response)
+
+        expect_any_instance_of(Faraday::Connection).to receive(:run_request).
+                                                       with(*params).
+                                                       and_return(response)
+
+        Vhx::Video.find(123, {}, { 'VHX-Client-IP' => '1.2.3.4' })
+      end
+    end
 
     describe '::retrieve' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: video_response))
-        expect{Vhx::Video.retrieve(123)}.to_not raise_error 
+        expect{Vhx::Video.retrieve(123)}.to_not raise_error
       end
     end
 
     describe '::list' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: videos_response))
-        expect{Vhx::Video.list()}.to_not raise_error 
+        expect{Vhx::Video.list()}.to_not raise_error
+      end
+
+      it "supports headers" do
+        params = [
+          :get,
+          "/videos",
+          nil,
+          { "VHX-Client-IP" => "1.2.3.4" },
+        ]
+        response = OpenStruct.new(body: videos_response)
+
+        expect_any_instance_of(Faraday::Connection).to receive(:run_request).
+                                                       with(*params).
+                                                       and_return(response)
+
+        Vhx::Video.list({}, { 'VHX-Client-IP' => '1.2.3.4' })
       end
     end
 
     describe '::all' do
       it 'does not error' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: videos_response))
-        expect{Vhx::Video.all()}.to_not raise_error 
+        expect{Vhx::Video.all()}.to_not raise_error
       end
     end
 
@@ -51,10 +83,26 @@ describe Vhx::Video do
       end
     end
 
-    describe '#udpate' do
+    describe '#update' do
       it 'raises error' do
         Vhx.connection.stub(:put).and_return(OpenStruct.new(body: video_response))
         expect{Vhx::Video.new(video_response).update({})}.to_not raise_error(NoMethodError)
+      end
+
+      it "supports headers" do
+        params = [
+          :put,
+          "https://api.vhx.tv/videos/1",
+          { title: "Video" },
+          { "VHX-Client-IP" => "1.2.3.4" },
+        ]
+        response = OpenStruct.new(body: videos_response)
+
+        expect_any_instance_of(Faraday::Connection).to receive(:run_request).
+                                                       with(*params).
+                                                       and_return(response)
+        video = Vhx::Video.new(video_response)
+        video.update({ title: "Video" }, { 'VHX-Client-IP' => '1.2.3.4' })
       end
     end
 
@@ -65,15 +113,14 @@ describe Vhx::Video do
     end
 
     describe '#files' do
-
       def files_response
         JSON.parse(File.read("spec/fixtures/sample_files_response.json"))
       end
-      
+
       it 'fetches linked association' do
         Vhx.connection.stub(:get).and_return(OpenStruct.new(body: files_response))
         files = Vhx::Video.new(video_response).files
-        expect(files.first.class).to eq(Vhx::Video::File) 
+        expect(files.first.class).to eq(Vhx::Video::File)
         expect(Vhx.connection).to have_received(:get)
       end
     end

--- a/vhx.gemspec
+++ b/vhx.gemspec
@@ -5,10 +5,10 @@ require 'vhx/version'
 Gem::Specification.new do |spec|
   spec.name           = 'vhx-ruby'
   spec.version        = Vhx::VERSION
-  spec.authors        = ['Sagar Shah']
-  spec.date           = '2017-01-06'
-  spec.description    = 'A Ruby wrapper for the Vhx developer API.'
-  spec.summary        = 'A Ruby wrapper for the Vhx developer API.'
+  spec.authors        = ['Sagar Shah', 'Kevin Sheurs']
+  spec.date           = '2017-02-03'
+  spec.description    = 'A Ruby wrapper for the VHX developer API.'
+  spec.summary        = 'A Ruby wrapper for the VHX developer API.'
   spec.email          = ['sagar@vhx.tv', 'dev@vhx.tv', 'wontae@vhx.tv', 'charlie@vhx.tv', 'kevin@vhx.tv', 'scott@vhx.tv']
   spec.homepage       = 'http://dev.vhx.tv/docs/api/'
   spec.license        = 'MIT'


### PR DESCRIPTION
For back-end API integrations, there are scenarios where we want the true client IP address to come through to our API. For things like logging, tracking, and geo-blocking concerns.

Per https://github.com/vhx/crystal/pull/2669, our API now supports a `VHX-Client-IP` header which we will respect as the client IP.

To use this, see below:

```ruby
# create
Vhx::Video.create({ title: 'My Video' }, { 'VHX-Client-IP' => '0.0.0.0' })

# retrieve
Vhx::Video.find(123, {}, { 'VHX-Client-IP' => '0.0.0.0' })

# update
video.update({ title: 'My Video' }, { 'VHX-Client-IP' => '0.0.0.0' })

# list
Vhx::Video.list({}, { 'VHX-Client-IP' => '0.0.0.0' })

# delete
Vhx::Customer.delete(123, {}, { 'VHX-Client-IP' => '0.0.0.0' })
```