### PR TITLE
Use instance version of obj_hash in generated methods

### DIFF
--- a/lib/vhx/utilities/vhx_object.rb
+++ b/lib/vhx/utilities/vhx_object.rb
@@ -75,12 +75,12 @@ module Vhx
       associations = (obj_hash.fetch('_links', {}).keys | obj_hash.fetch('_embedded', {}).keys).select{|k| ASSOCIATION_WHITELIST.include?(k)}
       associations.each do |association_method|
         self.class.send(:define_method, association_method) do |payload = {}|
-          if payload.empty? && obj_hash['_embedded'] && obj_hash['_embedded'].has_key?(association_method)
-            return instance_variable_set("@#{association_method}", fetch_embedded_association(obj_hash, association_method))
+          if payload.empty? && @obj_hash['_embedded'] && @obj_hash['_embedded'].has_key?(association_method)
+            return instance_variable_set("@#{association_method}", fetch_embedded_association(@obj_hash, association_method))
           end
 
-          if obj_hash['_links'] && obj_hash['_links'].has_key?(association_method)
-            return instance_variable_set("@#{association_method}", fetch_linked_association(obj_hash, association_method, payload))
+          if @obj_hash['_links'] && @obj_hash['_links'].has_key?(association_method)
+            return instance_variable_set("@#{association_method}", fetch_linked_association(@obj_hash, association_method, payload))
           end
 
           raise InvalidResourceError.new 'Association does not exist'


### PR DESCRIPTION
Because the block passed to `define_method` is not as strictly bound to it's lexical scope as is usual with Ruby blocks, the value of `obj_hash` was getting overwritten with each call to `create_associations`.  This uses the current instance's copy of `@obj_hash` instead which creates correct methods.