### PR TITLE
Bump Faraday version

### DIFF
--- a/lib/vhx/client.rb
+++ b/lib/vhx/client.rb
@@ -26,10 +26,9 @@ module Vhx
           faraday.use Vhx::Middleware::OAuth2, :vhx_client => self
         end
 
-        faraday.adapter Faraday.default_adapter
-
         faraday.use Vhx::Middleware::ErrorResponse
         faraday.response :json
+        faraday.adapter Faraday.default_adapter
       end
       @connection
     end

--- a/spec/objects/video_spec.rb
+++ b/spec/objects/video_spec.rb
@@ -86,7 +86,7 @@ describe Vhx::Video do
     describe '#update' do
       it 'raises error' do
         Vhx.connection.stub(:put).and_return(OpenStruct.new(body: video_response))
-        expect{Vhx::Video.new(video_response).update({})}.to_not raise_error(NoMethodError)
+        expect{Vhx::Video.new(video_response).update({})}.not_to raise_error
       end
 
       it "supports headers" do

--- a/vhx.gemspec
+++ b/vhx.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
 
   # Gems that must be intalled
-  spec.add_dependency 'faraday', '~> 0.9.1'
-  spec.add_dependency 'faraday_middleware', '~> 0.9.1'
+  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday_middleware', '~> 0.9'
 
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'


### PR DESCRIPTION
Relaxing the gemspec dependency requirements for Faraday gem makes it possible to include this gem into newer projects.